### PR TITLE
Add dkrefine + dkarchitect skills for ticket refinement

### DIFF
--- a/dk.sh
+++ b/dk.sh
@@ -75,6 +75,9 @@ doyaken() {
       echo "  dkls                  List worktrees"
       echo "  dkclean               Clean stale worktrees + gone branches"
       echo ""
+      echo "Refinement (pre-implementation):"
+      echo "  dk refine <N|description>  Refine a ticket — clarify with the user, raise risks, propose sub-tickets"
+      echo ""
       echo "Standalone completion (recovery / non-dk PRs):"
       echo "  dkcomplete             Monitor CI/reviews, address comments, close ticket"
       echo ""
@@ -976,6 +979,7 @@ dk() {
     echo "       dk --no-worktree <task>"
     echo "       dk --resume        Resume the most recent session"
     echo "       dk --from-pr <N>   Resume session linked to a PR"
+    echo "       dk refine <N|description>  Refine a ticket before implementation"
     echo ""
     echo "       dk init|config|install|uninstall|uninit|status|reload|help"
     return 1
@@ -1001,6 +1005,13 @@ dk() {
   if [[ $# -eq 0 ]]; then
     echo "Usage: dk --no-worktree <NUMBER|description>"
     return 1
+  fi
+
+  # Refine subcommand — intercept before worktree setup (read-only flow)
+  if [[ "$1" == "refine" ]]; then
+    shift
+    dkrefine "$@"
+    return $?
   fi
 
   # Route management subcommands to doyaken
@@ -1321,6 +1332,104 @@ $(__dk_provider_prompt)"
     fi
   fi
 
+  return $exit_code
+}
+
+# ─── dkrefine — standalone ticket refinement (pre-implementation) ─────────
+#
+# Single Claude session in plan mode. Drives the user through 3+ batches of
+# clarifying questions focused on high-level architecture and risks, then
+# presents a PO-grade refined ticket via ExitPlanMode. On approval, the
+# dkrefine skill posts architecture/risk comments and creates sub-tickets on
+# the configured tracker; the parent ticket's description is left untouched.
+#
+# No worktree, no commits, no branch rename. No phase-loop participation.
+
+unalias dkrefine 2>/dev/null; unfunction dkrefine 2>/dev/null
+dkrefine() {
+  __dk_refresh_provider || return 1
+
+  if [[ $# -eq 0 ]]; then
+    echo "Usage: dkrefine <NUMBER>           (e.g. dkrefine 123, dkrefine ENG-123)"
+    echo "       dkrefine \"<description>\"    (e.g. dkrefine \"streaming export pipeline\")"
+    return 1
+  fi
+
+  if ! command -v claude &>/dev/null; then
+    dk_error "Claude Code CLI not found in PATH."
+    dk_info "Install it from https://docs.anthropic.com/en/docs/claude-code then try again."
+    return 1
+  fi
+
+  # Must be in a git repo so the skill can read AGENTS.md and codebase context.
+  local repo_root
+  repo_root=$(dk_repo_root) || return 1
+
+  local raw_input="${(j: :)@}"
+
+  # Session label for the Claude session name — stable across invocations on
+  # the same input so the user can recognize it.
+  local session_label
+  if __dk_is_ticket "$raw_input"; then
+    session_label="ticket-${raw_input//[^0-9]/}"
+  else
+    local slug
+    slug=$(dk_slugify "${raw_input:0:40}")
+    session_label="${slug:-$(date +%s)}"
+  fi
+  local session_name="dkrefine-${session_label}"
+
+  # Unique state id so concurrent dkrefines don't collide on provider state.
+  local session_id
+  session_id="refine-$(dk_unique_session_id)"
+  dk_provider_cleanup_session_state "$session_id"
+
+  local branch
+  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  DOYAKEN — dkrefine (ticket refinement)"
+  echo ""
+  echo "  Branch: ${branch}"
+  echo "  Input:  ${raw_input:0:72}$([ ${#raw_input} -gt 72 ] && echo '...')"
+  echo "  Phase:  Refine (read-only until ExitPlanMode is approved)"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+
+  local plan_args=("${DK_PLAN_FLAGS[@]}" -n "$session_name")
+  plan_args+=(--append-system-prompt "You are in a dkrefine session — refinement only. Do NOT implement, do NOT commit, do NOT rename branches, do NOT set ticket status to In Progress. Stay in plan mode until you call ExitPlanMode. After approval, follow the dkrefine skill's write-back steps and stop.
+
+Standing platform constraints (apply to every refinement):
+- The system is multi-tenant. All new configuration, data, and computation must be tenant-scoped; cross-tenant isolation must be preserved.
+- The system is compute-heavy with a low user count (not high-traffic). Performance targets are about latency of a single computation and the scope of cascade recomputes, not requests-per-second. Naive whole-plan recomputes on every edit are a red flag — call out cascade scope, memoization, and incremental recomputation in the NFRs.
+
+Anchor every claim about where something lives to a real path in this repo. Reuse beats invent — justify every 'new X' against the existing X you found.")
+
+  DOYAKEN_SESSION_ID="$session_id" \
+  DOYAKEN_DIR="$DOYAKEN_DIR" \
+  __dk_claude "${plan_args[@]}" \
+    "This is a TECHNICAL refinement, not product discovery.
+
+Input: ${raw_input}
+
+Pre-flight (BEFORE EnterPlanMode — plan mode is read-only, so the architecture-map file write must happen first):
+ 0. Run: bash -lc 'test -f \"\$(git rev-parse --show-toplevel)/.doyaken/architecture.md\" && echo MAP_PRESENT || echo MAP_MISSING'
+    - If MAP_MISSING: invoke the Skill tool with skill: \"dkarchitect\" to bootstrap .doyaken/architecture.md (it writes the file directly; the user reviews and commits it themselves — the skill does NOT commit). Remember in working memory that the map was freshly built so you can flag it in the final summary.
+    - If MAP_PRESENT: continue.
+
+Now call EnterPlanMode, then invoke the Skill tool with skill: \"dkrefine\". Skill flow:
+ 1. Gather ticket context (if a ticket id).
+ 2. Read .doyaken/architecture.md (C4 levels 1-3) — this is the canonical current-state map and the source of valid Domain values for sub-tickets.
+ 3. Ask the user at least four batches of clarifying questions covering scope, architecture & integration, scale & multi-tenancy, and operational risk. Skip PO-flavor probes (value hypothesis, user stories).
+ 4. Identify the design patterns that fit, with each tied to a sub-ticket (or record '— none, all sub-tickets are mechanical' if genuinely mechanical).
+ 5. Decompose into AT LEAST TWO sub-tickets, each tagged with a Domain (a C4 container or component name from the architecture map verbatim), a t-shirt size (XS/S/M/L/XL), and a dominant design pattern. Decomposition is the defining output of dkrefine — if the work cannot be split, bail out and tell the user to run dk <ticket> directly.
+ 6. Present a /dkplan-style summary via ExitPlanMode, including a per-Domain rollup so the user can dispatch sub-tickets to owners.
+ 7. After approval, create the sub-tickets (with Domain in body and as a label if the tracker supports it) and post five comments on the parent (architecture+component map, design patterns, risks, NFRs, open questions+decision log). Do NOT modify the parent ticket's description. If the architecture map was bootstrapped in step 0, remind the user to commit .doyaken/architecture.md themselves.
+$(__dk_provider_prompt)"
+
+  local exit_code=$?
+  dk_provider_cleanup_session_state "$session_id"
   return $exit_code
 }
 

--- a/skills/dkarchitect/SKILL.md
+++ b/skills/dkarchitect/SKILL.md
@@ -1,0 +1,312 @@
+---
+name: "dkarchitect"
+description: "Bootstrap or refresh `.doyaken/architecture.md` as a C4 model (System Context, Container, Component — levels 1-3). Reads the codebase, emits mermaid C4 diagrams plus supporting prose. Does not commit."
+---
+
+# Skill: dkarchitect
+
+Bootstrap or refresh the project's canonical architecture map at `.doyaken/architecture.md`. The output is a **C4 model** at the first three levels:
+
+- **Level 1 — System Context**: the system in scope, its users, and external systems it talks to.
+- **Level 2 — Container**: deployable / runnable units inside the system (web app, API service, database, worker, queue, etc.) with their technologies.
+- **Level 3 — Component**: components inside each non-trivial container (modules / packages with well-defined interfaces).
+
+Level 4 (Code) is **intentionally out of scope** — it lives in the source itself and rots faster than a markdown file can track. See https://c4model.com for the underlying model.
+
+## When to Use
+
+- Invoked by `dkrefine` (via the Skill tool) when `.doyaken/architecture.md` does not exist.
+- Invoked directly inside a Claude session via `/dkarchitect [<focus area>]` to bootstrap a missing map or to refresh a stale one.
+
+**Plan mode is incompatible with this skill** — it writes a workspace file. If the agent is in plan mode when invoked, stop and tell the user to exit plan mode and re-invoke directly.
+
+This skill does **not** commit, does **not** branch, does **not** push, does **not** modify production code.
+
+## C4 Vocabulary (enforced)
+
+This is the operative definition of each abstraction. Apply it verbatim — do not invent synonyms ("pillar", "module", "service") in place of the C4 term.
+
+- **Person.** An actor, role, persona, or named individual that uses the software system. Examples: a planner, an admin, an oncall engineer, an external customer.
+- **Software System.** The highest level of abstraction. Something **the team owns, builds, deploys, and can see the internal implementation details of** — typically one source repository, owned by one team boundary. A software system delivers value to its users. **Not the same as** a product domain, bounded context, business capability, tribe, squad, or feature team. If you are unsure where the system boundary lies, ask the user.
+- **Container.** A **runtime** unit — an application or a data store — that needs to be running for the overall software system to work. Concrete examples:
+  - Server-side web app (Spring MVC, Rails, Django, ASP.NET, FastAPI, Express, …).
+  - Single-page application (React, Vue, Angular, Svelte, …).
+  - Desktop or mobile app.
+  - Console / batch / scheduled-job application.
+  - Serverless function (Lambda, Cloud Function, Azure Function, …).
+  - Database **schema** (Postgres, MySQL, Mongo, DynamoDB, …).
+  - Blob / object / content store (S3 bucket, GCS bucket, Azure Blob, CDN edge).
+  - Message **queue** or **topic** (each individual queue/topic is one container — not the broker).
+  - File system path.
+  - Long-lived shell daemon.
+- **What a container is NOT.** A JAR, DLL, NuGet package, npm module, Python package, Go package, namespace, folder, or repository — these are code-organisation constructs, not runtime units. Do not list them as containers.
+- **Component.** A grouping of related functionality encapsulated behind a well-defined interface, **executing in the same process space as other components in its container**. Examples: a controller, a domain service, a repository, an event publisher, an authorization middleware. A component is **not separately deployable** — the container is the deployable unit. Components are **not** packages, JARs, DLLs, or folders.
+- **Managed cloud services.** If the team owns the resource (its bucket, its schema, its queue), model it as a container regardless of who hosts the underlying hardware. S3 buckets, RDS schemas, SNS topics, SQS queues, Cloud SQL databases all count.
+- **Microservices scope rule (Conway's Law).** Two valid framings; pick one and apply it consistently across the map:
+  1. **Single team owns multiple services** → the whole thing is **one** software system; each microservice is a **group of containers** (API + DB schema + queues, …) inside that one boundary.
+  2. **Each service is owned by a different team** → each microservice is **its own** software system; pick the one in scope for this map (the one this repo / team owns) and draw external services as `System_Ext`.
+  - If the team topology is ambiguous from the codebase alone, **ask the user** before drawing.
+- **Queues and topics.** Each queue or topic is a container (data store). The broker that hosts them is **not** a container — it's deployment infrastructure. Alternatively, for a simple point-to-point relationship, model it implicitly via a `Rel(producer, consumer, "Sends X via queue Y", "AMQP")` label and omit the queue box (only when the queue is otherwise uninteresting).
+
+## Notation Rules (enforced)
+
+Every diagram in `architecture.md` must satisfy these:
+
+1. **Title.** Every mermaid block has a `title`.
+2. **Element type explicit.** Use `Person()`, `System()`, `System_Ext()`, `Container()`, `ContainerDb()`, `ContainerQueue()`, `Component()` — never a bare box. Each call has `id, "label", "technology", "description"` arguments where applicable (technology slot is mandatory for Container/Component).
+3. **Every relationship is unidirectional.** Use `Rel(from, to, "verb", "protocol/technology")`. The verb must be specific — `"Sends payment events"`, `"Queries account balance"`, `"Renders dashboard for"` — not `"Uses"` or `"Calls"`. For container-level relationships, the protocol/technology slot is mandatory (`HTTPS/JSON`, `SQL/TCP`, `AMQP`, `gRPC`, …).
+4. **Description on every element.** Short — one clause. Says what it does for the system, not what it is technically.
+5. **No deployment topology.** Clustering, load balancers, replication, failover, autoscaling groups belong in a deployment diagram and are **out of scope** for this skill. If a load balancer materially shapes the system architecture (e.g. it terminates TLS and authenticates), name it once in prose; otherwise omit.
+6. **Prose / table fallback.** Every diagram is followed by a prose table containing the same information. Mermaid C4 support is still experimental in many renderers — the table is the reliable rendering.
+7. **Diagram key.** Each section explicitly states the legend (what shape / `_Ext` suffix means). One paragraph per section, not per diagram.
+8. **Selectivity at Level 3.** Component diagrams are recommended **only when they add value**. Trivial containers (a Postgres database, a Redis cache, an SQS queue, a vanilla Nginx) get a one-line note in the Containers section instead of a full Level-3 diagram. Skip Level 3 outright for a container if its internals are mechanical (single-file lambda, thin CRUD service generated from schema).
+
+## Output Contract
+
+A single file at `<repo-root>/.doyaken/architecture.md` with this exact top:
+
+```
+---
+generated-by: dkarchitect
+last-refreshed: <YYYY-MM-DD>
+refreshed-from: <input or "manual refresh">
+---
+
+# Architecture Map
+
+> C4 model (levels 1-3). Level 4 (Code) is intentionally out of scope — read the source for that.
+```
+
+Followed by the six sections defined in **Step 4** below. The Level 1-3 sections (1-3) are canonical C4; sections 4-6 (Multi-tenancy, Plug-points, Data Flow) are **doyaken-specific supplementary** sections — they exist because every refinement needs them, not because they are part of C4.
+
+If the file already exists, **overwrite it** and announce so prominently in the final summary. Git history is the user's recovery path; this skill is not responsible for backups.
+
+## Steps
+
+### 1. Refuse if in plan mode
+
+Plan mode forbids writing non-plan files. Before doing anything else:
+
+- If the parent session is in plan mode (the agent was told to `EnterPlanMode` or sees plan-mode indicators), **stop**. Tell the user to call `ExitPlanMode` first (or run `dkarchitect` outside the plan-mode context) and re-invoke.
+
+### 2. Gather Context
+
+1. Determine the **repo root**: `git rev-parse --show-toplevel`. Refuse if not in a git repo.
+2. Read top-level documentation:
+   - `AGENTS.md`, `CLAUDE.md`, `README.md`
+   - Anything in `docs/` (especially `docs/architecture*`, `docs/adr*`)
+   - `.doyaken/doyaken.md` if present (integrations + rule references)
+3. Read the package manifests to detect the **tech stack** in each container: `package.json`, `pyproject.toml`, `requirements*.txt`, `go.mod`, `Cargo.toml`, `pom.xml`, `Gemfile`, etc.
+4. List the top-level service / app directories: `apps/`, `services/`, `packages/`, `cmd/`, `src/`. Each candidate is potentially a container, potentially its own software system — see scope decision below.
+5. Skim the entry-points (`main.ts`, `__main__.py`, `cmd/*/main.go`, etc.) to confirm what each container actually does.
+6. Locate **external** integration touchpoints: outbound HTTP clients, webhook handlers, env vars referencing external URLs (`*_BASE_URL`, `*_API_KEY`), deployment configs (`terraform/`, `pulumi/`, `helm/`).
+7. **Scope decision.** Decide what counts as **the software system in scope** for this map:
+   - If the repo is a single deployable product with one team → one software system, everything inside is containers.
+   - If the repo houses multiple microservices owned by the same team → one software system, each service is a group of containers (API + its schema + any queues it owns).
+   - If the repo houses microservices owned by different teams → each service is its own software system; this map covers **one** of them. Ask the user which one, or infer from doyaken.md / CODEOWNERS if unambiguous.
+   - If you cannot determine the scope from the codebase alone, **ask the user** before proceeding.
+
+If a focus-area argument was passed (e.g. `/dkarchitect billing`), bias the **Level 3 Component** detail toward that area — still cover all containers at Levels 1-2.
+
+### 3. Identify the C4 elements
+
+Build these lists in working memory before drawing any diagram. Apply the C4 Vocabulary above strictly.
+
+**People** (Level 1):
+
+- Discover from auth/permission code, UI routes, doyaken.md, README, CODEOWNERS.
+- Include primary users (planner, admin, end-customer, …) and operators (oncall, support) if relevant.
+
+**External Systems** (Level 1):
+
+- ERPs, identity providers, payment processors, mail/SMS gateways, analytics, BI warehouses, downstream consumers, upstream data sources.
+- Discover from outbound HTTP clients, webhook handlers, env vars referencing external URLs, deployment configs.
+
+**Containers** (Level 2) — apply the C4 Vocabulary container definition strictly:
+
+- One per deployable/runnable unit inside the in-scope software system. Include: web UIs, API services, workers, batch jobs, **each database schema**, caches, blob stores, **each queue/topic** owned by the system.
+- Do **not** include: JARs/DLLs/packages/modules/namespaces/folders. Do **not** include the message broker itself (only the queues/topics on it). Do **not** include clusters, load balancers, or other deployment topology.
+- Apply the microservices scope rule: do not draw services owned by other teams as containers — they are `System_Ext`.
+- For each container: name, technology (e.g. `Python/FastAPI`, `Postgres 16`, `Next.js 14`, `SQS`), responsibility (one sentence), path on disk, tenancy mode (see Section 4 below).
+
+**Components** (Level 3) — one diagram per **non-trivial** container; skip the rest with a one-line note:
+
+- Significant modules / packages / classes with a clear interface boundary. Examples to include: controllers, domain services, repositories, event publishers, authorization middleware.
+- Examples to **omit**: utility/helper modules, DTOs, model classes (they are data), one-off scripts.
+- All components in a Level-3 diagram execute in the same process space as the container — never split a single container's components across multiple diagrams.
+
+**Multi-tenancy boundary** (cross-cutting):
+
+- Where is `tenant_id` (or equivalent) enforced? Column? Schema-per-tenant? Row-level security? Request middleware? Document the pattern verbatim — every new entity must inherit it.
+
+**Reusable plug-points** (cross-cutting):
+
+- Existing strategy/plugin interfaces, registries, factories, cascade machinery, exception frameworks. List name, path, current implementations.
+
+### 4. Compose `architecture.md`
+
+Write the file with these sections, in this order. Every mermaid block is followed by a **prose table** equivalent — the table is the reliable fallback.
+
+#### Section 1 — System Context (Level 1)
+
+One `C4Context` mermaid block. Include every Person and every System (in-scope + external), with labelled `Rel` arrows.
+
+```mermaid
+C4Context
+  title System Context for <System Name>
+  Person(planner, "Planner", "Manages allocations day-to-day")
+  Person(admin, "Tenant Admin", "Configures tenant policy")
+  System(sys, "<System Name>", "<one-line responsibility>")
+  System_Ext(erp, "Customer ERP", "Source of truth for inventory")
+  System_Ext(bi, "BI Warehouse", "Downstream analytics consumer")
+  Rel(planner, sys, "Plans allocations via")
+  Rel(sys, erp, "Pulls inventory from", "Nightly batch / SFTP")
+  Rel(sys, bi, "Pushes computed allocations to", "Hourly / Snowflake")
+```
+
+Followed by:
+
+- One sentence stating the system's mission.
+- One sentence stating the value boundary (what's inside vs. outside).
+- A People-and-External-Systems table mirroring the diagram (`Element | Type | Description | Relationship to system`).
+- Diagram key paragraph: "Boxes labelled `System_Ext` are external systems the team does not own."
+
+#### Section 2 — Containers (Level 2)
+
+One `C4Container` mermaid block, then a **container table**.
+
+```mermaid
+C4Container
+  title Containers within <System Name>
+  Person(planner, "Planner")
+  System_Boundary(sys, "<System Name>") {
+    Container(web, "Web UI", "Next.js 14", "Planner interface")
+    Container(api, "API Service", "Python/FastAPI", "REST API")
+    Container(solver, "Solver", "Python", "Allocation engine")
+    ContainerDb(db, "Allocation DB", "Postgres 16", "Plans, allocations, tenants — row-level tenant isolation")
+    ContainerQueue(q_recompute, "Recompute Queue", "SQS", "Triggers cascade recomputes")
+    Container(jobs, "Job Runner", "Python/Celery", "Cascade workers")
+  }
+  System_Ext(erp, "Customer ERP")
+  Rel(planner, web, "Plans allocations via", "HTTPS")
+  Rel(web, api, "Calls", "HTTPS/JSON")
+  Rel(api, db, "Reads/writes", "SQL/TCP")
+  Rel(api, solver, "Requests solve", "HTTP/JSON")
+  Rel(api, q_recompute, "Publishes recompute jobs to", "AMQP")
+  Rel(jobs, q_recompute, "Consumes from", "AMQP")
+  Rel(jobs, db, "Updates allocations in", "SQL/TCP")
+  Rel(api, erp, "Pulls inventory from", "Nightly batch / SFTP")
+```
+
+Followed by a **container table**:
+
+| Container | Technology | Responsibility | Path | Tenancy mode |
+|-----------|------------|----------------|------|--------------|
+
+`Tenancy mode` is one of: `shared-DB row-level (tenant_id)`, `schema-per-tenant`, `stateless / from JWT`, `not tenant-aware (justified)`. Anything `not tenant-aware` requires a justification — global config, oncall tooling, etc.
+
+Diagram key paragraph: explain `ContainerDb` = data store; `ContainerQueue` = queue/topic; `System_Ext` = external system.
+
+#### Section 3 — Components (Level 3)
+
+One `C4Component` mermaid block per non-trivial container, each followed by a **component table** for that container:
+
+```mermaid
+C4Component
+  title Components inside API Service
+  Container_Boundary(api, "API Service") {
+    Component(allocs, "Allocations Controller", "FastAPI Router", "REST endpoints for /allocations")
+    Component(authz, "Tenant Authz", "FastAPI middleware", "Resolves tenant_id from JWT and sets session scope")
+    Component(repo, "Allocation Repository", "SQLAlchemy", "DB access for allocations")
+    Component(events, "Event Publisher", "Outbox pattern", "Emits domain events transactionally")
+  }
+  Rel(allocs, authz, "Authorises via")
+  Rel(allocs, repo, "Reads/writes via")
+  Rel(allocs, events, "Publishes domain events via")
+```
+
+| Component | Role | Path | Key dependencies |
+|-----------|------|------|------------------|
+
+For trivial containers (Postgres, Redis, SQS, an Nginx instance): one line in the Containers section is enough — `Allocation DB — schema documented in repo/migrations/, no Level-3 diagram needed`.
+
+#### Section 4 — Multi-tenancy Boundary (doyaken supplement)
+
+Not part of canonical C4. Required for every doyaken project because the platform constraint mandates it.
+
+Prose + a checklist. State the pattern verbatim, citing a file/line you read to confirm:
+
+> Every persisted entity has a `tenant_id UUID NOT NULL` column. Every API request resolves `tenant_id` from the JWT (`api/middleware/tenant_authz.py:42`) and the SQLAlchemy session sets `SET LOCAL app.tenant_id` so row-level security policies filter automatically. Background jobs receive `tenant_id` as a task argument; the worker re-applies the session variable before any query.
+
+New-entity checklist:
+
+- [ ] Carries `tenant_id`?
+- [ ] Inherits the standing isolation mechanism (RLS / scoped session / etc.)?
+- [ ] Tenant-aware unique constraints?
+- [ ] Tenant-aware test fixtures?
+
+#### Section 5 — Reusable Plug-points (doyaken supplement)
+
+Not part of canonical C4. Required for the dkrefine "reuse beats invent" check.
+
+| Interface | Path | Purpose | Registered implementations | v2 candidates |
+|-----------|------|---------|---------------------------|---------------|
+
+Plus one sentence per plug-point on **how to add a new implementation** (do you register, subclass, decorate, etc.).
+
+#### Section 6 — Data Flow (doyaken supplement)
+
+System-level data flow narrative — what flows where, sync vs. async, persistence boundaries. Keep it short (5-10 sentences). If a single hot path materially clarifies the system, include one `sequenceDiagram` mermaid block; otherwise skip — long sequence diagrams belong in ADRs, not the canonical map.
+
+### 5. Quality Gate
+
+Before writing the file, verify all of the following.
+
+**C4 conformance:**
+
+1. Every mermaid block has a `title`.
+2. Every element uses an explicit C4 type call (`Person`, `System`, `System_Ext`, `Container`, `ContainerDb`, `ContainerQueue`, `Component`).
+3. Every Container and Component has a technology specified.
+4. Every `Rel(…)` has a specific verb (not `"Uses"` / `"Calls"` alone). Every container-level `Rel(…)` has a protocol/technology label.
+5. Every diagram is followed by a prose table containing the same information.
+6. Every section has a diagram-key paragraph explaining shape/suffix semantics.
+
+**Coverage:**
+
+7. Level 1 has at least one Person and at least one External System (zero of either is suspicious — call it out if genuinely none).
+8. Level 2 lists every directory under `apps/`, `services/`, `packages/` that contains an entry-point. No silent omissions.
+9. Level 2 includes every owned database **schema**, blob store, queue, and topic as its own container.
+10. The microservices scope rule was applied consistently — no service owned by another team appears as a `Container`; if it appears at all, it is `System_Ext`.
+11. Level 3 has at least one diagram per non-trivial Level-2 container, **or** an explicit one-line "trivial — see container table" note for skipped containers.
+
+**Doyaken cross-cutting:**
+
+12. Multi-tenancy section is non-empty and cites a file/line from the actual code.
+13. Every Level-2 container has a Tenancy mode set in the container table.
+14. Plug-points section lists every existing strategy/registry interface discovered in §3 (or `— none found`).
+
+**Hygiene:**
+
+15. Every path cited in the file resolves to a real path in the repo. No invented filenames.
+16. No JARs / DLLs / packages / modules / namespaces / folders are listed as Containers or Components.
+17. No deployment topology (clusters, LBs, replication, autoscaling) appears in any diagram.
+
+### 6. Write the File
+
+1. Compute `.doyaken/architecture.md` path relative to the repo root.
+2. If the file already exists, capture its `last-refreshed` value (if any) — you will mention "overwriting <date>" in the final summary.
+3. Write the new content.
+4. Print a final summary:
+   - Confirmation that the file was written (or overwritten — name the previous `last-refreshed` date).
+   - One-line summary of each Level-2 container.
+   - Scope-decision call-out (`Single software system: <name>` or `Multi-team — scoped to <name>`).
+   - The exact git command for the user to commit: `git add .doyaken/architecture.md && git commit -m "docs: bootstrap architecture map"` (or `"refresh"` for overwrites).
+   - **The skill never commits.** The user owns the commit.
+
+## Notes
+
+- `dkarchitect` is the canonical source of `.doyaken/architecture.md`. Anything else that needs the map (`dkrefine` today, future skills tomorrow) **reads** the file rather than rebuilding inline.
+- C4 is notation-independent in principle — this skill commits to **mermaid C4 + prose-table fallback** for consistency. Tools that auto-generate or auto-validate the diagrams (Structurizr DSL, PlantUML / C4-PlantUML) are out of scope for v1.
+- Mermaid's C4 support is still labelled experimental in many renderers — the prose tables in each section are the reliable rendering. Always include both.
+- This skill is intentionally narrow: build / refresh one markdown file at C4 levels 1-3. It does **not** generate ADRs, deployment diagrams, sequence diagrams for arbitrary flows, system-landscape diagrams (multiple systems), or Level-4 code diagrams.
+- When invoked from `dkrefine` via the Skill tool, the parent session is expected to be **outside** plan mode (the `dkrefine` shell wrapper handles this ordering). If you find yourself in plan mode anyway, refuse per Step 1.

--- a/skills/dkrefine/SKILL.md
+++ b/skills/dkrefine/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: "dkrefine"
+description: "Technical refinement: map the architecture, clarify scope, identify design patterns, decompose into estimated sub-tickets — no implementation."
+---
+
+# Skill: dkrefine
+
+Technical refinement of an engineering effort. Map the system's current architecture (or read the cached map), interrogate scope with the user, identify the design patterns that fit, decompose the work into estimated sub-tickets, and raise risks. Never implement.
+
+## When to Use
+
+- Invoked by the `dkrefine` shell wrapper (`dk refine <N|description>` or `dkrefine <N|description>`).
+- Invoked directly inside an existing Claude session via `/dkrefine <input>`.
+
+This skill is **not** part of the autonomous `dk` lifecycle. Do **not** write Phase 1 markers, do **not** activate the Stop-hook audit loop, do **not** rename branches, do **not** set ticket status to "In Progress", do **not** commit, do **not** create a worktree.
+
+The defining output of `dkrefine` is a **decomposition into multiple estimated sub-tickets**, plus architecture, pattern, and risk comments on the parent. If the work cannot decompose into at least two independently shippable sub-tickets, `dkrefine` is the wrong tool — bail out (per §12 in Step 6) and tell the user to run `dk <ticket>` directly.
+
+## Standing Platform Constraints
+
+Two constraints apply to **every** refinement, regardless of ticket. The agent must address both during the question loop and re-check them in the quality gate before presenting the draft:
+
+- **Multi-tenancy.** All configuration, data, and computation are tenant-scoped. Cross-tenant isolation must be preserved by every proposed change. Configuration surfaces are per-tenant by default; any setting that is _not_ per-tenant must be flagged explicitly with a justification.
+- **Compute-heavy, low-user-count profile.** The platform is not high-traffic; it is heavy per-request computation (solvers, allocations, projections, cascades). Performance NFRs target the latency of a single computation and the scope of cascade recomputes — not requests-per-second. Caching, memoization, incremental recomputation, and cascade-scope minimization are first-class design tools. A proposal that triggers a naive O(N²) recompute over the whole plan on every edit is a red flag and must be challenged.
+
+## Steps
+
+### 1. Gather Context
+
+Use the integrations configured in `doyaken.md § Integrations`. Skip any that are "not configured".
+
+**Ticket tracker (if input is a ticket id or URL):**
+
+- Read the ticket — title, description, acceptance criteria, relations, comments. Comments often hold prior decisions and stakeholder context.
+- If the tracker supports it, check the assignee — but do **not** reassign and do **not** change status. Refinement is not work-start.
+- Do **not** rename the branch. Do **not** push.
+
+**Freeform input (no ticket id):**
+
+- Derive intent from the user's description, the current branch name, and local documentation.
+- Skip all tracker write-back steps later.
+
+**Related work:**
+
+- If the ticket has related or blocking issues, read those too.
+- `git log --oneline -20` for recent local context.
+
+### 2. Architecture Map (Read-only)
+
+Foundational. Every later decision — design patterns, sub-tickets, risks, estimates — references this map. **This skill does not build the map** — that is the `dkarchitect` skill's job. `dkrefine` only reads it.
+
+#### 2a. Read `.doyaken/architecture.md`
+
+- **Present** → read it. It is a C4 model (System Context, Container, Component) plus multi-tenancy boundary and plug-point catalogue. Treat as the canonical current-state view. Skim the codebase to spot obvious drift against the map; note any drift in the Decision Log (§15) but do **not** rewrite the file silently.
+- **Present but `last-refreshed` is older than 90 days** → use it, but flag staleness in the Decision Log and suggest the user run `/dkarchitect` to refresh.
+- **Absent** → **stop and tell the user to run `/dkarchitect` first**, then re-invoke `/dkrefine`. The shell wrapper (`dk refine`) handles this bootstrap automatically outside plan mode; direct `/dkrefine` invocations need to run `/dkarchitect` themselves first because plan mode is read-only.
+
+The C4 containers and components in the map are the **domains** sub-tickets will be tagged with in §12 — read them carefully now so you can attribute each sub-ticket to one.
+
+#### 2b. Build the Codebase Component Map (specific to this change)
+
+Overlay on `.doyaken/architecture.md`. Each refinement produces its own component map — which pillars (C4 containers / components) this particular change touches.
+
+| Pillar | Path(s) on disk | Current responsibility | Touched by this change? |
+| ------ | --------------- | ---------------------- | ----------------------- |
+
+Pillars not touched are listed as `None — <reason>` so the omission is deliberate, not an oversight. Pillar names should match the C4 container or component names in `.doyaken/architecture.md` verbatim — this is what makes the Domain field in §12 cross-referenceable.
+
+### 3. Internal Architecture Check
+
+Before asking the user anything, answer these five questions to yourself. If you cannot answer all five with confidence, do more reading in Step 2 first.
+
+1. What system boundaries does this cross? (services, pillars, ownership)
+2. Which existing components participate, and which need to change? _(cite paths)_
+3. What is the data/control flow before vs. after?
+4. What invariants or contracts could break? (schema, API, tenant isolation, idempotency, cascade ordering)
+5. What does a senior architect challenge about this direction? Especially: scale within a single tenant's plan, cascade explosion, solver/engine interaction, plug-point design.
+
+### 4. Mandatory Question Loop
+
+**Bar: at least four `AskUserQuestion` batches.** The per-call limit (typically three questions per call) is _only_ a per-batch limit — the _total_ number of questions is unbounded. Keep asking until every dimension below is either answered, explicitly deferred by the user, or proven non-applicable.
+
+Group related questions in a batch. After each answer, re-check assumptions and unknowns — if new ones surface, ask another batch before drafting.
+
+This is a **technical** refinement — engineering decomposition, not product discovery. Skip "value hypothesis", "user stories", and other PO-flavor probes. Cover **every** dimension below across the batches:
+
+- **Goals & scope.** What does done look like _technically_? What is explicitly out of scope (and which OoS items are roadmap candidates vs. permanent)? Cross-project / cross-service interfaces.
+- **Architecture & integration.** Chosen approach vs. alternatives; new components vs. extensions of existing ones (cite the existing ones by path); data model impact (new entities, new attributes, identity-vs-attribute split); sync/async; API/contract changes; backward compatibility; **interface pluggability** — what should be a strategy/plug-point so v2 does not need a schema migration.
+- **Scale & multi-tenancy (mandatory, every ticket).**
+  - Tenant-scoping: which new config/data is tenant-scoped? How is isolation preserved?
+  - Compute profile: cost shape of the operation (per plan? per batch? per movement? O(N) in what)? Realistic upper bound for N in a single tenant's plan?
+  - Cascade scope: when a single edit fires, what is the minimum recompute set vs. the worst-case recompute set? Is there a guarded "manual full re-run" vs. "incremental cascade" distinction?
+  - Caching/memoization: which intermediate results are reusable across edits?
+  - Tenant-config surface: what does the admin configure per tenant? Defaults? Per-product overrides?
+- **Operational & risk.** Blast radius; rollback story; observability (per-failure reasoning logs, latency P50/P99 instrumentation, KPI value logging); security/permissions; rollout (flag, gradual, big-bang); dependencies on other teams/tickets; edge cases the implementer will hit first.
+
+If the user defers a dimension, that dimension must appear verbatim under **Open Questions** in the draft. Do **not** silently make decisions on the user's behalf — even decisions that seem obvious — because the user's domain context, deadlines, downstream coordination, and prior decisions are invisible from inside the codebase.
+
+### 5. Design-Pattern Analysis
+
+After the conversation has converged on an approach, identify the design patterns that fit. **Surface only patterns that genuinely improve the design** — do not retrofit a pattern onto a trivial sub-ticket just to have one.
+
+For each pattern you propose, capture:
+
+- **Pattern name.** Standard vocabulary preferred (Strategy, Repository, Adapter, Observer, Factory, Pipeline, Plugin/Registry, Command, Chain of Responsibility, Template Method, Decorator, Memento, Saga, Outbox, …).
+- **Why it fits.** The specific variability, coupling, or change-frequency concern it addresses on this ticket.
+- **Where it lives in code.** Path or proposed location.
+- **Sub-ticket(s) that embody it.** Each sub-ticket should be tied to at most one dominant pattern.
+- **Alternative considered.** One sentence on what was rejected and why (e.g. "considered a Factory but the construction is trivial — Strategy alone is enough").
+
+Cross-reference against §2c (Codebase Component Map): if the same pattern already exists in this codebase, **reuse it, do not reinvent it**. Cite the existing implementation's path.
+
+If a refinement genuinely involves only mechanical work (config, copy, plumbing) with no pattern worth naming, record `— none, all sub-tickets are mechanical` explicitly. Silent absence is not allowed.
+
+### 6. Assemble the Refinement Material
+
+This is your **working memory**, not the user-facing output. Build all fifteen sections below so you have the inputs you need for the quality gate, the `ExitPlanMode` summary in Step 8, and the tracker write-back in Step 9. If a section is genuinely empty for this ticket, mark it `— none` rather than omitting it; an empty section is data too.
+
+1. **Problem Statement (technical).** The change, broken into the natural engineering sub-domains the conversation surfaced (e.g. "Creation", "Allocation", "Expiration", "Visibility"). These sub-domains drive the grouping of Verification Criteria below.
+2. **Codebase Component Map.** The table from §2c, finalised. Every entry cites a real path in this repo.
+3. **Impact Domains.** Per-pillar **Heavy / Medium / Light / None** table with a one-paragraph reason per pillar. Walk every pillar discovered in Step 2, not a fixed list. Pillars not touched are listed as `None — <reason>`.
+4. **Cross-component / cross-team interfaces.** For each Heavy- or Medium-impact pillar, name the contract: who owns what, where the boundary is in code, what shape data crosses it.
+5. **Assumptions.** Explicit list of every assumption that survived the question loop. Each line ends with a source: `— user said X` / `— universally safe` / `— deferred to implementation` / `— deferred by user`.
+6. **Edge Cases.** Bulleted list. Each edge case names the trigger and the expected behavior (or the expected exception), not just "what if X". Lean engineering: race conditions, partial failures, concurrent edits, replay, retries, ordering, timezone/DST, encoding.
+7. **Out of Scope.** Bulleted list. Each item: one-line reason and a marker — _roadmap candidate_ vs. _permanent OoS_. Out of Scope being empty is itself a smell — refinement that excludes nothing has not yet drawn its boundaries.
+8. **Verification Criteria.** Numbered, **each a testable assertion with a concrete observable outcome** — a test name, a query, an HTTP probe, a log assertion, a metric threshold. Prose-only criteria ("works correctly", "is performant") must be rewritten as mechanically checkable assertions. Group by the engineering sub-domains from §1.
+9. **Non-Functional Requirements.** Broken into sub-sections:
+   - **Performance.** Latency targets for the dominant operations (single computation, cascade trigger latency, KPI calc time, etc.). If the user has not given a number, use a placeholder and flag it as `TBD-during-refinement`.
+   - **Observability.** What to log on success vs. failure; aggregate metrics; per-failure reasoning logs where the operation is debug-heavy.
+   - **Configurability (per-tenant).** Every configuration surface introduced or changed. Tenant-scoping is implicit; explicitly note any setting that is _not_ per-tenant and why.
+   - **Pluggability (architectural).** For each plug-point identified in §10, state the interface name, what v1 ships as the only registered implementation, and what v2/v3 candidates exist.
+   - **Multi-tenancy.** Explicit section confirming tenant-scoping of new data/config, isolation guarantees, and any deviation from the platform's standing isolation stance.
+10. **Design Patterns.** The full output of Step 5. Table format preferred: `Pattern | Why it fits | Location | Sub-ticket(s) | Alternative considered`.
+11. **Risk Register.** Table `Risk | Likelihood (L/M/H) | Impact (L/M/H) | Mitigation | Owner`. At least one risk per Heavy-impact pillar.
+12. **Proposed Sub-tickets.** Numbered list. Each carries:
+    - **Title**
+    - **Domain** — the C4 container (Level 2) or component (Level 3) name from `.doyaken/architecture.md` that this sub-ticket primarily lives in. Used downstream to identify the responsible owner. Must match a name in the architecture map verbatim — if a sub-ticket spans multiple containers, pick the one where the riskiest change lands and note the spillover in **Cross-component / cross-team interfaces** (§4).
+    - **Scope** — one line
+    - **Depends-on** — sub-ticket numbers it sequences after (or `—` for independent)
+    - **Primary paths** — files / packages touched
+    - **Size** — `XS` / `S` / `M` / `L` / `XL` (scale below)
+    - **Pattern** — dominant design pattern from §10, or `— none` if not applicable
+
+    Sub-tickets are sized so a single `dk <subticket>` lifecycle can complete each one. Sequencing must respect the dependency edges.
+
+    **At minimum two sub-tickets are required.** If the work genuinely cannot be split into two or more independently shippable pieces, stop and tell the user that `dkrefine` is the wrong tool: they should run `dk <ticket>` directly. Do not create a single sub-ticket that mirrors the parent.
+
+    **T-shirt size calibration:**
+    - **XS** — < 0.5 day. Config, copy, single-file tweak with tests.
+    - **S** — 0.5–1 day. One module, well-understood pattern, low integration risk.
+    - **M** — 1–3 days. Multi-file feature, modest integration, requires tests.
+    - **L** — 3–5 days. Cross-pillar work, new entity or new contract, non-trivial migration.
+    - **XL** — 1–2 weeks. New subsystem, multiple new contracts, coordination across pillars. **An XL is a smell — try to split further before accepting it.**
+    - **XXL** — refuse. Break into smaller sub-tickets and re-estimate.
+13. **Estimation Summary.** Roll-up of §12:
+    - Total count and size mix (e.g. "5 sub-tickets: 1×L, 3×M, 1×S").
+    - **Critical path** — longest dependency chain, with summed size.
+    - **Parallelizable** — which sub-tickets can run concurrently.
+    - **Riskiest-to-estimate** — which sub-tickets carry the most schedule risk (typically the L/XL ones with new contracts or unknown integrations).
+14. **Open Questions.** Every dimension the user explicitly deferred plus any architectural question you could not resolve. Each numbered, with the owner who can answer.
+15. **Decision Log.** Running list of decisions made _during this refinement_, date-stamped. Include the architecture-map status: `Read existing map (last-refreshed YYYY-MM-DD)` or `Built map fresh — user to review and commit`.
+
+### 7. Quality Gate
+
+Before presenting via `ExitPlanMode`, walk this checklist against the material in Step 6. If any item fails, go back and fix the material.
+
+1. Every Verification Criterion is a testable assertion with an observable outcome.
+2. Every Heavy-impact pillar has at least one entry in Risk Register, Sub-tickets, and (if applicable) NFRs.
+3. Every new entity / configuration explicitly states its multi-tenancy stance.
+4. Every "we will add new X" line has been justified against existing X in the codebase, citing the existing X's path.
+5. The Performance NFR names the dominant cost shape (per plan / per batch / per movement) and an upper-bound expectation for N.
+6. Out of Scope is non-empty.
+7. Every dimension from Step 4 is either answered in the material or explicitly listed under Open Questions.
+8. **§12 contains at least two sub-tickets, each tagged with a Domain, t-shirt size, and design pattern (`— none` allowed for pattern, never for size or domain).** If decomposition is not possible, bail out per the §12 instruction.
+9. **Every Domain in §12 matches a C4 container or component name in `.doyaken/architecture.md` verbatim.** A Domain that doesn't appear in the architecture map is either a typo or a sign the map is stale — fix the typo, or re-run `/dkarchitect` to refresh the map.
+10. **`.doyaken/architecture.md` exists and was read in §2a.** If it was missing, the skill should already have stopped earlier and asked the user to run `/dkarchitect`.
+11. **§10 (Design Patterns) is non-empty.** A genuinely mechanical refinement records `— none, all sub-tickets are mechanical` explicitly.
+
+### 8. Present via `ExitPlanMode`
+
+This is the user-facing output. Model it on what `/dkplan` presents — short, scannable, plan-style — **not** the fifteen-section material. The detailed material lives in working memory now and goes to the tracker in Step 9.
+
+Include exactly these blocks, in this order:
+
+1. **Refinement summary** — 2–4 sentences distilled from §1 (Problem Statement). What changes, technically; what success looks like.
+2. **Architecture map status** — one line: `Read existing map: .doyaken/architecture.md (last-refreshed YYYY-MM-DD)`. If freshly built by `/dkarchitect` earlier in this run, say so and remind the user to commit it.
+3. **Architectural direction** — 3–6 bullets summarising the chosen approach: which existing components extend, which (if any) are new and why, key contracts, sync/async stance, pluggability points. Cite paths.
+4. **Design patterns chosen** — one line per pattern from §10: `<Pattern> at <location> — <why> [sub-tickets: …]`.
+5. **Proposed sub-tickets** — numbered list rendered from §12. One line per sub-ticket: `<title> [domain: <C4 name>] [<size>] [<pattern>] — <scope> [depends-on: …] [paths: …]`.
+6. **Estimation summary** — total count + size mix, critical path size, riskiest-to-estimate (1–2 sentences), and a **per-domain rollup** (sub-ticket count and size mix grouped by Domain — helps the user see workload distribution across owners).
+7. **Files / areas touched** — high-level, derived from §2 (Codebase Component Map). Not file-by-file — the affected pillars and their entry points.
+8. **Assumptions surfaced and answered** — one line per item from §5: `<assumption> — user said <X>` / `<assumption> — universally safe` / `<assumption> — deferred`.
+9. **Residual open questions** — numbered, rendered from §14. Each with the owner who can answer.
+10. **Risks** — bullet list rendered from §11. One line per risk: `<risk> (<L/M/H>×<L/M/H>) — mitigation: <…> — owner: <…>`.
+
+Do **not** paste the Codebase Component Map, Edge Cases, full Verification Criteria, NFRs, or Decision Log into `ExitPlanMode`. Those land on the parent ticket as comments in Step 9 — pasting them into the plan-mode UI as well would bury the parts the user actually needs to approve.
+
+Do **not** write any phase markers — this command does not participate in the Doyaken phase lifecycle.
+
+**Do not begin tracker write-back until the user approves the plan.**
+
+### 9. Write Back After Approval
+
+Only if a ticket tracker is configured **and** the input was a ticket id. For freeform input or no-tracker setups, skip this step and print a brief summary instead.
+
+1. **Create sub-tickets.** For each item in §12:
+   - Linear: `save_issue` with `parent` relation to the original ticket. If the tracker supports labels, set a label matching the **Domain** (e.g. `domain:api-service`).
+   - GitHub Issues: `gh issue create` with the parent referenced in the body (e.g. "Parent: #123") and a `--label "domain:<name>"` flag if the label exists in the repo (skip the flag silently if it doesn't — do not auto-create labels).
+   - Body includes: **Domain**, scope line, **size**, **dominant pattern (with path)**, depends-on list, primary paths touched, and a back-link to the parent.
+   - Capture the returned id / URL.
+2. **Post five separate comments on the parent ticket** (separate so they can be linked individually):
+   1. **Architecture + Component Map.** Link to `.doyaken/architecture.md` (note its `last-refreshed` date), then paste the Codebase Component Map (§2) + Impact Domains (§3).
+   2. **Design Patterns** — §10 table.
+   3. **Risk Register** — §11.
+   4. **NFRs** — §9 (Performance / Observability / Configurability / Pluggability / Multi-tenancy).
+   5. **Open Questions + Decision Log** — §14 + §15.
+3. **Never edit the parent ticket's description.** The parent description is owned by whoever wrote the ticket; refinement output goes in comments and child tickets.
+4. **If `/dkarchitect` was run earlier in this `dk refine` invocation** (i.e. the architecture map was built fresh), remind the user in the final summary to commit `.doyaken/architecture.md` themselves: `git add .doyaken/architecture.md && git commit -m "docs: bootstrap architecture map"`. The skill never commits.
+5. Print a final summary: parent ticket link, every created sub-ticket link (with **Domain** + size + pattern), the five comment URLs, and the **per-domain rollup** from §8 step 6 so the user can dispatch sub-tickets to owners.
+
+## Notes
+
+- `dkrefine` does **not** call `TaskCreate` — task creation is `/dkplan`'s job during implementation.
+- `dkrefine` does **not** branch, commit, push, or modify code. The one exception is writing `.doyaken/architecture.md` in §2b — that is a workspace file, not a code edit, and is **never** committed by the skill.
+- `dkrefine` does **not** chain to implementation automatically. After approval and write-back, suggest the user run `dk <subticket>` on any created child ticket to begin implementation.
+- If the user invokes `/dkrefine` from inside an autonomous `dk` lifecycle session by mistake, decline and tell them to start a separate `dk refine` session — mixing refinement into the lifecycle would skip the Stop-hook expectations of the active phase.


### PR DESCRIPTION
Closes #42

## Summary
- New `dkrefine` skill: technical refinement that reads the architecture map, runs ≥4 batches of clarifying questions, identifies design patterns, and decomposes work into estimated sub-tickets (each tagged with Domain, t-shirt size, and dominant design pattern).
- New `dkarchitect` skill: bootstraps or refreshes `.doyaken/architecture.md` as a C4 model at levels 1–3 (System Context, Container, Component) with mermaid C4 blocks plus prose-table fallbacks; includes doyaken-specific multi-tenancy and plug-points sections. Never commits.
- `dk.sh`: new `dkrefine()` shell function and `dk refine <input>` subcommand. The starter prompt pre-flights `.doyaken/architecture.md` before `EnterPlanMode` (plan mode forbids file writes) and invokes `/dkarchitect` on cold-start, so `dkrefine` can always read from a present map.
- Refinement output: ≥2 sub-tickets (with `Domain` in body and as a label where the tracker supports it) plus five comments on the parent (architecture + component map, design patterns, risks, NFRs, open questions + decision log). The parent ticket's description is never modified.

## Test plan
- [ ] `zsh -n dk.sh` is syntax-clean.
- [ ] `dk refine` with no args prints usage and exits non-zero.
- [ ] Freeform input: `dk refine "design X"` enters plan mode, runs `/dkrefine`, asks ≥4 question batches, presents via `ExitPlanMode`; no tracker write-back.
- [ ] Cold-start (no `.doyaken/architecture.md`): `dk refine <ticket>` first invokes `/dkarchitect` outside plan mode, writes the C4 map, then enters plan mode and runs `/dkrefine`.
- [ ] Warm-start (map present): bootstrap is skipped; refinement reads the existing map.
- [ ] Ticket write-back: after `ExitPlanMode` approval, ≥2 sub-tickets are created with `Domain` in body, five comments are posted on the parent, parent description is unchanged.
- [ ] `/dkarchitect` invoked directly outside plan mode in a test repo produces a valid C4 file (mermaid blocks + prose tables, every Container has a technology, every `Rel` has a specific verb + protocol).

Generated by Doyaken