### PR TITLE
docs(dex): sync context and promote hook failure-mode memory

### DIFF
--- a/.dex/dex.md
+++ b/.dex/dex.md
@@ -27,14 +27,15 @@ dx.sh                Main shell functions (zsh only, ~2800 lines)
 settings.json        Claude Code hook definitions template
 install.sh           Quick-start installer wrapper
 agents/              Sub-agents (symlinked to ~/.claude/agents/)
-bin/                 CLI scripts: install, uninstall, init, uninit, config, status, sync, maintain, log, rename, tools, ui-capture, dxcodex, install-settings, status-line
-docs/                Extended docs: guards, autonomous mode
+bin/                 CLI scripts: install, uninstall, init, uninit, config, status, sync, maintain, log, tools, ui-capture, dxcodex, install-settings, status-line
+docs/                Extended docs: guards, autonomous mode, RTK token reduction
 hooks/               Claude Code hooks + guard handler
   guards/            Built-in guard rules (5 rules)
-lib/                 Shared shell libraries (10 modules: common, agent-tools, codex, git, maintenance, output, provider, session, ui-capture, worktree)
+lib/                 Shared shell libraries (11 modules: common, agent-tools, codex, git, maintenance, output, provider, rtk, session, ui-capture, worktree)
 prompts/             Prompt templates for skills/agents
   phase-audits/      Phase-specific audit prompts (1-6 + prompt-loop)
-skills/              Lifecycle skills (17 total, linked into ~/.claude/skills/)
+research/            DX evaluation harness (scenarios, scoring, improvement loop)
+skills/              Lifecycle skills (18 total, linked into ~/.claude/skills/)
 .dex/                Per-project config (this directory)
   providers.json     Repo-local default agent/provider profile
 ```
@@ -61,11 +62,21 @@ skills/              Lifecycle skills (17 total, linked into ~/.claude/skills/)
 When an integration is "not configured", skip any workflow steps that reference it.
 For ticket tracking: use the enabled tracker for all status updates, context gathering, and ticket lifecycle management.
 
+## Tooling
+
+Dex bootstraps [RTK](https://github.com/rtk-ai/rtk) — a Rust output-filtering
+CLI — during `dx install`, `dx init`, `dx sync`, and `dx tools bootstrap` to cut
+command-output tokens. Claude Code uses a fail-open PreToolUse rewrite hook
+(`hooks/rtk-claude-hook.sh`) that runs *after* the guards; Codex receives
+instruction-based RTK guidance instead. RTK is optional — set `DX_RTK_ENABLED=0`
+to disable. See `docs/rtk-token-reduction.md`.
+
 ## Provider
 
 This repo uses `.dex/providers.json` to default Dex runs to the Codex agent with
 `gpt-5.3-codex`. Use `dx --agent claude` for a one-run fallback to the built-in
-Claude/Opus 4.7 profile.
+Claude/Opus 4.7 profile, or `dx --model <model>` to override the model passed to
+the selected agent.
 
 ## Reviewers
 

--- a/.dex/memory/domains/architecture-decisions.md
+++ b/.dex/memory/domains/architecture-decisions.md
@@ -50,3 +50,55 @@ Future agent behavior:
 - When a feature truly needs a framework-specific path (e.g., Playwright for
   UI capture), gate it on detection or explicit user configuration rather than
   assuming presence.
+
+## M-008: PreToolUse Bash hooks run guards-first and split fail-closed vs fail-open
+
+Domain: architecture-decisions
+Status: active
+Scope: settings.json PreToolUse hook arrays, hooks/rtk-claude-hook.sh, hooks/guard-handler.py, hooks/stop-sound.sh, lib/rtk.sh, bin/install-settings.sh hook-provenance logic
+Applies to phases: any phase that adds, reorders, or edits a Claude Code hook; guard and tooling maintenance
+Applies to paths: settings.json, hooks/*.sh, hooks/guard-handler.py, lib/rtk.sh
+Last verified: 2026-05-27
+Recheck when: a new PreToolUse hook is added, hook registration order in settings.json changes, the RTK integration changes, or any hook's failure mode (exit code) changes
+
+Lesson:
+Dex's Claude Code hooks divide by responsibility into two failure contracts.
+Security/guard hooks fail CLOSED: `guard-handler.py` exits 2 to block a
+dangerous command, and surrounding logic treats other non-zero exits as errors,
+not blocks. Enhancement and notification hooks fail OPEN: they must exit 0 on
+every error path so a missing or broken optional tool never blocks or breaks the
+user's command. In `settings.json` the PreToolUse/Bash array is ordered so the
+guard runs before the RTK rewrite hook; a rewrite/enhancement hook must never
+run before the guard, or it could mutate a command the guard would have blocked.
+
+Evidence:
+- `71ab07b feat(tooling): bootstrap RTK token reduction` adds
+  `hooks/rtk-claude-hook.sh`, commented "Fail-open Claude Code hook", which
+  exits 0 when RTK is disabled, the binary is unresolved, the payload is empty,
+  or the rewrite fails.
+- `settings.json` registers two PreToolUse/Bash hooks in order: `guard-handler.py`
+  then `rtk-claude-hook.sh`.
+- `docs/rtk-token-reduction.md`: "Bash tool calls now run through Dex guards
+  first... If RTK is unavailable or fails, the wrapper exits successfully and
+  leaves the original command untouched."
+- `hooks/stop-sound.sh` is a "best-effort" notification hook that also exits 0
+  unconditionally.
+- Fail-closed side: `8b62b46 fix(guards): harden destructive command detection`,
+  `4290403 feat: block unsafe raw codex delegation`, and `guard-handler.py`
+  exit 2 == block (see [[security-guards]] M-005).
+- `bin/install-settings.sh` records `rtk-claude-hook.sh` in its Dex-owned hook
+  provenance detector, keeping install/uninstall scoped (see
+  [[workflow-operations]] M-004).
+
+Future agent behavior:
+- When adding a PreToolUse Bash hook that rewrites or enhances commands, fail
+  open: exit 0 on missing tooling, empty payload, or any internal error, and
+  leave the original command untouched.
+- When adding a security/guard hook, fail closed: exit 2 to block; never let a
+  detection failure silently allow a dangerous command.
+- Preserve guard-before-rewrite ordering in `settings.json`. Do not register a
+  rewrite/enhancement hook ahead of `guard-handler.py`.
+- When adding any Dex-owned hook, register it in the `bin/install-settings.sh`
+  provenance detector so uninstall removes only Dex's entries (M-004).
+- Reference `.dex/dex.md` § Tooling and `docs/rtk-token-reduction.md` for the
+  RTK integration surface before changing it.

--- a/.dex/memory/domains/security-guards.md
+++ b/.dex/memory/domains/security-guards.md
@@ -10,7 +10,7 @@ Status: active
 Scope: hooks/guard-handler.py detectors, hooks/guards/destructive-commands.md, hooks/guards/raw-codex-delegation.md, hooks/guards/sensitive-files.md, hooks/guards/hardcoded-secrets.md, .dex/guards/*.md
 Applies to phases: any phase that runs a Bash tool; guard authoring/maintenance
 Applies to paths: hooks/guard-handler.py, hooks/guards/*.md, .dex/guards/*.md
-Last verified: 2026-05-15
+Last verified: 2026-05-27
 Recheck when: a new dangerous-command class is added, a guard adds a new event type, or the guard frontmatter parser changes
 
 Lesson:

--- a/.dex/memory/domains/workflow-operations.md
+++ b/.dex/memory/domains/workflow-operations.md
@@ -93,7 +93,7 @@ Status: active
 Scope: bin/install-settings.sh, bin/uninstall.sh, bin/config.sh, settings.json install/uninstall paths, MCP server configuration
 Applies to phases: install, uninstall, config (outside the per-ticket lifecycle)
 Applies to paths: bin/install-settings.sh, bin/uninstall.sh, bin/config.sh, ~/.claude/.dex-install-state.json
-Last verified: 2026-05-15
+Last verified: 2026-05-27
 Recheck when: install/uninstall logic changes, settings.json schema changes, MCP server config rules change, or the install-state file moves
 
 Lesson:
@@ -111,6 +111,10 @@ Evidence:
   entries with install-state provenance, fails existing-settings installs
   without jq, avoids overwriting global MCP server definitions.
 - `bin/install-settings.sh` declares `INSTALL_STATE_FILE="$CLAUDE_DIR/.dex-install-state.json"`.
+- `71ab07b feat(tooling): bootstrap RTK token reduction` adds the new
+  `rtk-claude-hook.sh` to the Dex-owned hook provenance detector in
+  `bin/install-settings.sh`, confirming new hooks are registered for scoped
+  uninstall rather than left untracked (see [[architecture-decisions]] M-008).
 
 Future agent behavior:
 - When modifying install or uninstall logic for `~/.claude/settings.json` or

--- a/.dex/memory/index.md
+++ b/.dex/memory/index.md
@@ -16,7 +16,7 @@ directory until promoted via a reviewable diff.
 | review-quality | domains/review-quality.md | Phase 3 review waves; editing `agents/review-*.md`, `agents/self-reviewer.md`, `agents/review-verifier.md`, `prompts/review-wave.md`, `prompts/review.md`, `prompts/phase-audits/3-review*.md`, or `skills/dxreview*/` | active |
 | workflow-operations | domains/workflow-operations.md | Lifecycle phase ownership, in-place vs worktree mode, and shared global config; editing `dx.sh` phase routing, `skills/dx*/SKILL.md`, `prompts/phase-audits/`, `hooks/phase-loop.sh`, `bin/install-settings.sh`, `bin/uninstall.sh`, `bin/uninit.sh`, `bin/config.sh`, or session/branch state code | active |
 | security-guards | domains/security-guards.md | Editing `hooks/guard-handler.py`, `hooks/guards/*.md`, or `.dex/guards/*.md`; adding any new dangerous-command detector | active |
-| architecture-decisions | domains/architecture-decisions.md | Adding or editing any skill, prompt, agent, or research harness; reviewing portability across repositories | active |
+| architecture-decisions | domains/architecture-decisions.md | Adding or editing any skill, prompt, agent, or research harness; adding/reordering Claude Code hooks or editing `settings.json` hook arrays; reviewing portability across repositories | active |
 
 ## Entries
 
@@ -29,6 +29,7 @@ directory until promoted via a reviewable diff.
 | M-005 | security-guards | Dangerous-command guards must use syntax-aware detection, not pattern matching |
 | M-006 | architecture-decisions | Dex skills and prompts must be codebase-agnostic and discover tooling at runtime |
 | M-007 | review-quality | Review waves must build context first, run deterministic checks before semantic review, isolate acceptance criteria, and only count true CLEAN waves |
+| M-008 | architecture-decisions | Bash PreToolUse hooks run guards-first; guards fail closed, enhancement hooks (RTK) fail open |
 
 ## Retrieval Rules
 

--- a/.dex/review-rules.md
+++ b/.dex/review-rules.md
@@ -22,6 +22,9 @@ Path-specific review focus for Dex review waves.
 - Bash scripts should use `#!/usr/bin/env bash` and `set -euo pipefail`.
 - User-facing output should use Dex output helpers when common.sh is sourced.
 - Hook behavior is security-sensitive; fail closed for dangerous operations.
+- In `settings.json`, security guards must stay ordered before any
+  rewrite/enhancement Bash hook; enhancement hooks (e.g. `rtk-claude-hook.sh`)
+  must fail open so a missing or broken optional tool never blocks the command.
 - After changes, run `bash -n <file>` and `shellcheck` when available.
 
 ## `hooks/guard-handler.py`

--- a/.dex/rules/architecture.md
+++ b/.dex/rules/architecture.md
@@ -8,11 +8,17 @@ Hooks defined in `settings.json`, referenced by paths to Dex scripts:
 |------|-------|--------|---------|
 | SessionStart | Startup | `load-ticket-context.sh` | Load ticket context, detect focus areas |
 | UserPromptSubmit | User prompt | `user-prompt-submit.sh` | Pause scheduled Phase 6 watchers during manual user work |
-| PreToolUse | Before Bash/Edit/Write | `guard-handler.py` | Block/warn on dangerous patterns |
+| PreToolUse | Before Bash/Edit/Write | `guard-handler.py` | Block/warn on dangerous patterns (fail-closed) |
+| PreToolUse | Before Bash | `rtk-claude-hook.sh` | Fail-open RTK command rewrite; runs *after* `guard-handler.py` |
 | PostToolUse | After `git commit` | `post-commit-guard.sh` | Validate commit format via guards |
 | Stop | Claude tries to stop | `phase-loop.sh`, `stop-sound.sh` | Phase audit loop plus best-effort macOS sound notification |
 | PreCompact | Before compaction | `pre-compact.sh` | Preserve Dex context across compaction |
 | SessionEnd | Session ends | `session-end.sh` | Record session end metadata |
+
+PreToolUse/Bash hooks run in registration order: `guard-handler.py` first
+(fail-closed — exit 2 blocks the command), then `rtk-claude-hook.sh` (fail-open —
+always exits 0). Security guards must precede any rewrite/enhancement hook so a
+rewrite can never bypass a guard.
 
 ## Phase Audit Loops
 

--- a/.dex/rules/shell.md
+++ b/.dex/rules/shell.md
@@ -27,7 +27,7 @@ All scripts use `set -euo pipefail`. Use early returns, not deep nesting.
 source "$DEX_DIR/lib/common.sh"
 ```
 
-Sourcing `common.sh` automatically sources `git.sh`, `session.sh`, `output.sh`, `worktree.sh`, `provider.sh`, `codex.sh`, and `ui-capture.sh`.
+Sourcing `common.sh` automatically sources `git.sh`, `session.sh`, `output.sh`, `worktree.sh`, `provider.sh`, `codex.sh`, `ui-capture.sh`, `rtk.sh`, `agent-tools.sh`, and `maintenance.sh`.
 
 ## Output
 


### PR DESCRIPTION
## What

`dx sync` refresh of `.dex/` project context and repo memory after two
unreleased features landed on `main`: the RTK token-reduction subsystem
(`71ab07b`) and provider agent/model overrides (`6b681cb`). All changes are
docs/memory only.

## Project context drift fixed

- **`dex.md`** — `lib/` was listed as 10 modules; it is now 11 (added `rtk`).
  Skill count 17 → 18. Removed `rename` from the `bin/` list (no `bin/rename.sh`
  exists). Added the `research/` evaluation harness to the structure. Added a
  **Tooling** section describing the RTK bootstrap and fail-open rewrite hook.
  Documented the `dx --model` override alongside `--agent`.
- **`rules/shell.md`** — the "common.sh sources" list omitted `rtk.sh`,
  `agent-tools.sh`, and `maintenance.sh`; `common.sh` sources all three.
- **`rules/architecture.md`** — added `rtk-claude-hook.sh` to the hook table and
  recorded that PreToolUse/Bash hooks run guards-first.
- **`review-rules.md`** — reviewers now check guard-before-rewrite ordering and
  that enhancement hooks fail open.

## Memory

- **New M-008** (architecture-decisions): PreToolUse Bash hooks run guards-first,
  and split by failure contract — security guards fail closed (`exit 2` blocks),
  enhancement hooks (RTK, stop-sound) fail open. Verified against `settings.json`
  ordering, `rtk-claude-hook.sh`, `guard-handler.py`, and
  `docs/rtk-token-reduction.md`.
- **M-004 / M-005** re-verified against current code; dates refreshed. M-004
  gains evidence that the RTK hook was correctly added to the Dex-owned hook
  provenance detector in `bin/install-settings.sh`.
- Index updated: M-008 row added; architecture-decisions retrieval scope widened
  to hook/`settings.json` edits.

## Verification

- Only `.dex/*.md` changed (no shell scripts), so the repo shell gates
  (`shellcheck`, `bash -n`, `zsh -n`) are not applicable.
- Structural checks: M-008 carries all 10 required memory fields; the index
  references all 4 domain files and lists 8 entries; dex.md counts now match the
  working tree.

Generated by Dex.
