### PR TITLE
feat(guards): add await-in-loop N+1 detector

### DIFF
--- a/docs/guards.md
+++ b/docs/guards.md
@@ -69,6 +69,17 @@ For `env_var: DX_PROVIDER_ENGINE`, `guard-handler.py` treats the current Dex ses
 | `block-raw-codex-delegation` | bash | block | Raw Codex agent-work commands while the resolved provider engine is `codex-plugin`, including `codex`, `codex exec`, `codex e`, `codex review`, direct `dx_provider_codex` helper delegation, API-key login forms, shell-nested forms including literal variable-expanded and escape-decoded `bash -c`/`eval`/stdin payloads, generated heredoc scripts, direct executable script paths, readable executed or sourced script files, Python/Node/Ruby/Perl interpreter payloads that launch Codex, launch wrappers such as `nice`, `timeout`, `xargs`, and `find -exec`, and fail-closed shell execution from unresolved/unreadable script paths or unknown stdin/process-substitution producers; also blocks versioned/scoped package-runner forms such as `npx @openai/codex@latest` and runner shell payloads such as `npx -c "codex exec ..."` and `npm exec --call "codex exec ..."`; use `bin/dxcodex.sh` instead |
 | `warn-sensitive-files` | commit | warn | `.env`, credentials, keys, certs in commits |
 | `warn-hardcoded-secrets` | file | warn | `API_KEY = "..."`, `ACCESS_KEY`, `JWT_SECRET`, and other credential patterns in code |
+| `warn-await-in-loop` | file | warn | `await` directly inside a `for`/`while` loop body (N+1 query / sequential I/O). Uses the `await-in-loop` detector: brace-aware, skips `for await` async iteration and awaits inside closures collected for a later `Promise.all` |
+
+### Built-in detectors
+
+Some guards set `detector:` instead of `pattern:` to use a parser in `hooks/guard-handler.py` (registered in `guard_detector_matches`) for checks regex can't express reliably:
+
+| Detector | Used by | What it parses |
+|----------|---------|----------------|
+| `destructive-commands` | `block-destructive-commands` | Shell tokenization of `rm -rf` / `dd` / `mkfs` targets, incl. wrappers and nested payloads |
+| `raw-codex-delegation` | `block-raw-codex-delegation` | Shell/script delegation to the Codex CLI under the `codex-plugin` provider |
+| `await-in-loop` | `warn-await-in-loop` | Brace-matched `for`/`while` bodies, flagging an `await` that isn't inside a nested closure |
 
 Note: Conventional commit format validation is handled by `hooks/post-commit-guard.sh` directly (not via guards) because commit events combine file paths and the message into a single text, making it impossible to write a guard pattern that targets only the commit message.
 

--- a/docs/guards.md
+++ b/docs/guards.md
@@ -69,7 +69,7 @@ For `env_var: DX_PROVIDER_ENGINE`, `guard-handler.py` treats the current Dex ses
 | `block-raw-codex-delegation` | bash | block | Raw Codex agent-work commands while the resolved provider engine is `codex-plugin`, including `codex`, `codex exec`, `codex e`, `codex review`, direct `dx_provider_codex` helper delegation, API-key login forms, shell-nested forms including literal variable-expanded and escape-decoded `bash -c`/`eval`/stdin payloads, generated heredoc scripts, direct executable script paths, readable executed or sourced script files, Python/Node/Ruby/Perl interpreter payloads that launch Codex, launch wrappers such as `nice`, `timeout`, `xargs`, and `find -exec`, and fail-closed shell execution from unresolved/unreadable script paths or unknown stdin/process-substitution producers; also blocks versioned/scoped package-runner forms such as `npx @openai/codex@latest` and runner shell payloads such as `npx -c "codex exec ..."` and `npm exec --call "codex exec ..."`; use `bin/dxcodex.sh` instead |
 | `warn-sensitive-files` | commit | warn | `.env`, credentials, keys, certs in commits |
 | `warn-hardcoded-secrets` | file | warn | `API_KEY = "..."`, `ACCESS_KEY`, `JWT_SECRET`, and other credential patterns in code |
-| `warn-await-in-loop` | file | warn | `await` directly inside a `for`/`while` loop body (N+1 query / sequential I/O). Uses the `await-in-loop` detector: brace-aware, skips `for await` async iteration and awaits inside closures collected for a later `Promise.all` |
+| `warn-await-in-loop` | file | warn | `await` directly inside a loop body, which can serialize independent I/O. Uses the `await-in-loop` detector: handles common brace- and colon-delimited loop bodies, skips async iteration forms and awaits inside nested closures or methods |
 
 ### Built-in detectors
 
@@ -79,7 +79,7 @@ Some guards set `detector:` instead of `pattern:` to use a parser in `hooks/guar
 |----------|---------|----------------|
 | `destructive-commands` | `block-destructive-commands` | Shell tokenization of `rm -rf` / `dd` / `mkfs` targets, incl. wrappers and nested payloads |
 | `raw-codex-delegation` | `block-raw-codex-delegation` | Shell/script delegation to the Codex CLI under the `codex-plugin` provider |
-| `await-in-loop` | `warn-await-in-loop` | Brace-matched `for`/`while` bodies, flagging an `await` that isn't inside a nested closure |
+| `await-in-loop` | `warn-await-in-loop` | Common `for`/`foreach`/`while` loop bodies, flagging an `await` that isn't inside a nested closure or method |
 
 Note: Conventional commit format validation is handled by `hooks/post-commit-guard.sh` directly (not via guards) because commit events combine file paths and the message into a single text, making it impossible to write a guard pattern that targets only the commit message.
 

--- a/hooks/guard-handler.py
+++ b/hooks/guard-handler.py
@@ -3743,6 +3743,120 @@ def has_raw_codex_delegation(text, depth=0, cwd=None):
     return False
 
 
+_LOOP_HEADER_RE = re.compile(r'\bfor\b(?P<await>\s+await\b)?|\bwhile\b')
+_AWAIT_TOKEN_RE = re.compile(r'(?<![\w$])await(?![\w$])')
+_FUNCTION_TOKEN_RE = re.compile(r'(?<![\w$])function(?![\w$])')
+
+
+def strip_comments_and_strings(text):
+    """Blank string/template literals and comments so loop/brace/await scanning
+    only sees real code. Strings are blanked first (so a `//` or `/*` inside a
+    string is already gone), then line and block comments are removed."""
+    cleaned = code_without_string_literals(text)
+    cleaned = re.sub(r'/\*.*?\*/', ' ', cleaned, flags=re.DOTALL)
+    cleaned = re.sub(r'//[^\n]*', '', cleaned)
+    return cleaned
+
+
+def matching_brace_body(text, open_index):
+    """Return the body between the '{' at open_index and its matching '}'. If the
+    brace is never closed (a partial Edit fragment), the body runs to end-of-text
+    so the pattern is still caught."""
+    depth = 0
+    i = open_index
+    n = len(text)
+    while i < n:
+        char = text[i]
+        if char == '{':
+            depth += 1
+        elif char == '}':
+            depth -= 1
+            if depth == 0:
+                return text[open_index + 1:i]
+        i += 1
+    return text[open_index + 1:]
+
+
+def body_has_unnested_await(body):
+    """True if body contains an `await` that is NOT inside an inner function or
+    braced arrow scope. Awaits inside `if`/`try`/`for` blocks still count (they
+    run sequentially within the loop); awaits inside a closure belong to a
+    different async context (e.g. promises collected for a later Promise.all)
+    and do not."""
+    i = 0
+    n = len(body)
+    scope_is_fn = []          # one bool per currently-open '{'
+    next_brace_is_fn = False  # does the next '{' open a function scope?
+    while i < n:
+        if body.startswith('function', i) and _FUNCTION_TOKEN_RE.match(body, i):
+            next_brace_is_fn = True
+            i += 8
+            continue
+        if body.startswith('=>', i):
+            j = i + 2
+            while j < n and body[j].isspace():
+                j += 1
+            if j < n and body[j] == '{':
+                next_brace_is_fn = True
+            i += 2
+            continue
+        char = body[i]
+        if char == '{':
+            scope_is_fn.append(next_brace_is_fn)
+            next_brace_is_fn = False
+            i += 1
+            continue
+        if char == '}':
+            if scope_is_fn:
+                scope_is_fn.pop()
+            i += 1
+            continue
+        if body.startswith('await', i) and _AWAIT_TOKEN_RE.match(body, i):
+            if not any(scope_is_fn):
+                return True
+            i += 5
+            continue
+        i += 1
+    return False
+
+
+def has_await_in_loop(text):
+    """Detect `await` used directly inside a `for`/`while` loop body — the
+    language-level signature of an N+1 query or sequential I/O. `for await`
+    async iteration is intentional and is not flagged."""
+    cleaned = strip_comments_and_strings(text)
+    n = len(cleaned)
+    for header in _LOOP_HEADER_RE.finditer(cleaned):
+        if header.group('await'):  # `for await (...)` — async iteration
+            continue
+        i = header.end()
+        while i < n and cleaned[i].isspace():
+            i += 1
+        if i >= n or cleaned[i] != '(':
+            continue
+        depth = 0
+        while i < n:
+            char = cleaned[i]
+            if char == '(':
+                depth += 1
+            elif char == ')':
+                depth -= 1
+                if depth == 0:
+                    i += 1
+                    break
+            i += 1
+        while i < n and cleaned[i].isspace():
+            i += 1
+        if i < n and cleaned[i] == '{':
+            body = matching_brace_body(cleaned, i)
+        else:
+            semicolon = cleaned.find(';', i)
+            body = cleaned[i:semicolon if semicolon != -1 else n]
+        if body_has_unnested_await(body):
+            return True
+    return False
+
+
 def guard_detector_matches(guard, text):
     detector = guard.get('detector', '')
     if not detector:
@@ -3751,6 +3865,8 @@ def guard_detector_matches(guard, text):
         return has_destructive_command(text)
     if detector == 'raw-codex-delegation':
         return has_raw_codex_delegation(text)
+    if detector == 'await-in-loop':
+        return has_await_in_loop(text)
     print(f"[guard:{guard.get('name', 'unnamed')}] skipped — unknown detector: {detector}", file=sys.stderr)
     return False
 

--- a/hooks/guard-handler.py
+++ b/hooks/guard-handler.py
@@ -3743,9 +3743,17 @@ def has_raw_codex_delegation(text, depth=0, cwd=None):
     return False
 
 
-_LOOP_HEADER_RE = re.compile(r'\bfor\b(?P<await>\s+await\b)?|\bwhile\b')
+_LOOP_HEADER_RE = re.compile(
+    r'(?<![\w$])(?:(?P<async_prefix>async|await)\s+)?'
+    r'(?P<kind>foreach|for|while)(?:\s+(?P<await_suffix>await)\b)?'
+    r'(?![\w$])'
+)
 _AWAIT_TOKEN_RE = re.compile(r'(?<![\w$])await(?![\w$])')
 _FUNCTION_TOKEN_RE = re.compile(r'(?<![\w$])function(?![\w$])')
+_CONTROL_SCOPE_WORDS = {
+    'catch', 'class', 'do', 'else', 'finally', 'for', 'foreach', 'if',
+    'switch', 'try', 'while', 'with',
+}
 
 
 def strip_comments_and_strings(text):
@@ -3755,7 +3763,38 @@ def strip_comments_and_strings(text):
     cleaned = code_without_string_literals(text)
     cleaned = re.sub(r'/\*.*?\*/', ' ', cleaned, flags=re.DOTALL)
     cleaned = re.sub(r'//[^\n]*', '', cleaned)
+    cleaned = re.sub(r'#[^\n]*', '', cleaned)
     return cleaned
+
+
+def previous_nonspace_index(text, index):
+    i = index
+    while i >= 0 and text[i].isspace():
+        i -= 1
+    return i
+
+
+def previous_word(text, index):
+    i = previous_nonspace_index(text, index)
+    end = i + 1
+    while i >= 0 and (text[i].isalnum() or text[i] in {'_', '$'}):
+        i -= 1
+    return text[i + 1:end], i
+
+
+def matching_open_paren(text, close_index):
+    depth = 0
+    i = close_index
+    while i >= 0:
+        char = text[i]
+        if char == ')':
+            depth += 1
+        elif char == '(':
+            depth -= 1
+            if depth == 0:
+                return i
+        i -= 1
+    return -1
 
 
 def matching_brace_body(text, open_index):
@@ -3777,12 +3816,131 @@ def matching_brace_body(text, open_index):
     return text[open_index + 1:]
 
 
+def matching_parenthesized_header_end(text, open_index):
+    depth = 0
+    i = open_index
+    n = len(text)
+    while i < n:
+        char = text[i]
+        if char == '(':
+            depth += 1
+        elif char == ')':
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        i += 1
+    return n
+
+
+def colon_body(text, colon_index):
+    line_end = text.find('\n', colon_index)
+    if line_end == -1:
+        return text[colon_index + 1:]
+    inline = text[colon_index + 1:line_end]
+    if inline.strip():
+        return inline
+
+    header_line_start = text.rfind('\n', 0, colon_index) + 1
+    header_indent = len(text[header_line_start:colon_index]) - len(text[header_line_start:colon_index].lstrip())
+    body_start = line_end + 1
+    body_end = body_start
+    n = len(text)
+    while body_end < n:
+        next_end = text.find('\n', body_end)
+        if next_end == -1:
+            next_end = n
+        line = text[body_end:next_end]
+        if line.strip():
+            indent = len(line) - len(line.lstrip())
+            if indent <= header_indent:
+                break
+        body_end = next_end + 1
+    return text[body_start:body_end]
+
+
+def loop_body_after_header(text, header):
+    if header.group('async_prefix') in {'async', 'await'} or header.group('await_suffix'):
+        return None
+
+    i = header.end()
+    n = len(text)
+    while i < n and text[i].isspace():
+        i += 1
+
+    if i < n and text[i] == '(':
+        i = matching_parenthesized_header_end(text, i)
+    else:
+        while i < n and text[i] not in {'{', ':', '\n', ';'}:
+            i += 1
+
+    while i < n and text[i].isspace() and text[i] != '\n':
+        i += 1
+    if i < n and text[i] == '{':
+        return matching_brace_body(text, i)
+    if i < n and text[i] == ':':
+        return colon_body(text, i)
+
+    statement_end = n
+    for delimiter in (';', '\n'):
+        found = text.find(delimiter, i)
+        if found != -1:
+            statement_end = min(statement_end, found)
+    return text[i:statement_end]
+
+
+def skip_arrow_expression_body(text, index):
+    i = index
+    n = len(text)
+    paren_depth = bracket_depth = brace_depth = 0
+    while i < n:
+        char = text[i]
+        if char == '(':
+            paren_depth += 1
+        elif char == '[':
+            bracket_depth += 1
+        elif char == '{':
+            brace_depth += 1
+        elif char == ')':
+            if paren_depth == 0 and bracket_depth == 0 and brace_depth == 0:
+                return i
+            paren_depth = max(paren_depth - 1, 0)
+        elif char == ']':
+            if paren_depth == 0 and bracket_depth == 0 and brace_depth == 0:
+                return i
+            bracket_depth = max(bracket_depth - 1, 0)
+        elif char == '}':
+            if paren_depth == 0 and bracket_depth == 0 and brace_depth == 0:
+                return i
+            brace_depth = max(brace_depth - 1, 0)
+        elif char in {';', ',', '\n'} and paren_depth == 0 and bracket_depth == 0 and brace_depth == 0:
+            return i
+        i += 1
+    return i
+
+
+def brace_opens_callable_scope(body, brace_index, next_brace_is_fn):
+    if next_brace_is_fn:
+        return True
+
+    prev = previous_nonspace_index(body, brace_index - 1)
+    if prev == -1:
+        return False
+    if body[prev] == ')':
+        open_paren = matching_open_paren(body, prev)
+        if open_paren == -1:
+            return False
+        word, _ = previous_word(body, open_paren - 1)
+        return bool(word) and word not in _CONTROL_SCOPE_WORDS
+
+    word, _ = previous_word(body, brace_index - 1)
+    return bool(word) and word not in _CONTROL_SCOPE_WORDS
+
+
 def body_has_unnested_await(body):
     """True if body contains an `await` that is NOT inside an inner function or
-    braced arrow scope. Awaits inside `if`/`try`/`for` blocks still count (they
-    run sequentially within the loop); awaits inside a closure belong to a
-    different async context (e.g. promises collected for a later Promise.all)
-    and do not."""
+    callable scope. Awaits inside `if`/`try`/nested loop blocks still count;
+    awaits inside closures or methods belong to a different async context and
+    do not."""
     i = 0
     n = len(body)
     scope_is_fn = []          # one bool per currently-open '{'
@@ -3798,11 +3956,14 @@ def body_has_unnested_await(body):
                 j += 1
             if j < n and body[j] == '{':
                 next_brace_is_fn = True
+            else:
+                i = skip_arrow_expression_body(body, j)
+                continue
             i += 2
             continue
         char = body[i]
         if char == '{':
-            scope_is_fn.append(next_brace_is_fn)
+            scope_is_fn.append(brace_opens_callable_scope(body, i, next_brace_is_fn))
             next_brace_is_fn = False
             i += 1
             continue
@@ -3821,37 +3982,14 @@ def body_has_unnested_await(body):
 
 
 def has_await_in_loop(text):
-    """Detect `await` used directly inside a `for`/`while` loop body — the
-    language-level signature of an N+1 query or sequential I/O. `for await`
-    async iteration is intentional and is not flagged."""
+    """Detect `await` used directly inside a loop body. Async iteration forms
+    such as `for await`, `async for`, and `await foreach` are intentional and
+    are not flagged."""
     cleaned = strip_comments_and_strings(text)
-    n = len(cleaned)
     for header in _LOOP_HEADER_RE.finditer(cleaned):
-        if header.group('await'):  # `for await (...)` — async iteration
+        body = loop_body_after_header(cleaned, header)
+        if body is None:
             continue
-        i = header.end()
-        while i < n and cleaned[i].isspace():
-            i += 1
-        if i >= n or cleaned[i] != '(':
-            continue
-        depth = 0
-        while i < n:
-            char = cleaned[i]
-            if char == '(':
-                depth += 1
-            elif char == ')':
-                depth -= 1
-                if depth == 0:
-                    i += 1
-                    break
-            i += 1
-        while i < n and cleaned[i].isspace():
-            i += 1
-        if i < n and cleaned[i] == '{':
-            body = matching_brace_body(cleaned, i)
-        else:
-            semicolon = cleaned.find(';', i)
-            body = cleaned[i:semicolon if semicolon != -1 else n]
         if body_has_unnested_await(body):
             return True
     return False

--- a/hooks/guards/await-in-loop.md
+++ b/hooks/guards/await-in-loop.md
@@ -1,0 +1,18 @@
+---
+name: warn-await-in-loop
+enabled: true
+event: file
+detector: await-in-loop
+action: warn
+---
+
+WARNING: `await` inside a `for`/`while` loop — likely an N+1 query or sequential I/O.
+
+Each iteration waits for the previous one, so N rows become N sequential round-trips. This is a leading cause of slow endpoints and, on the server side, database connection-pool exhaustion (every awaited call holds resources while the loop crawls).
+
+Prefer one of:
+
+- **Batch the work** — collect the inputs and issue one set-based call instead of one per row (e.g. `WHERE id IN (...)`, a JOIN, or a bulk insert/upsert).
+- **Parallelize independent calls** — build an array of promises in the loop and `await Promise.all(...)` once, after it. Bound the fan-out with a concurrency limit when the list is large.
+
+Keep the sequential `await` only when each iteration genuinely depends on the previous one, or when you are deliberately rate-limiting — and say so in a comment. Note: `for await (...)` async iteration and awaits inside a closure collected for a later `Promise.all` are not flagged.

--- a/hooks/guards/await-in-loop.md
+++ b/hooks/guards/await-in-loop.md
@@ -6,13 +6,13 @@ detector: await-in-loop
 action: warn
 ---
 
-WARNING: `await` inside a `for`/`while` loop — likely an N+1 query or sequential I/O.
+WARNING: `await` inside a loop - possible sequential I/O.
 
-Each iteration waits for the previous one, so N rows become N sequential round-trips. This is a leading cause of slow endpoints and, on the server side, database connection-pool exhaustion (every awaited call holds resources while the loop crawls).
+Each iteration waits for the previous one. That may be required when the next step depends on the previous result, but it can also turn independent work into a slow chain of network, database, file, SDK, or browser calls.
 
 Prefer one of:
 
-- **Batch the work** — collect the inputs and issue one set-based call instead of one per row (e.g. `WHERE id IN (...)`, a JOIN, or a bulk insert/upsert).
-- **Parallelize independent calls** — build an array of promises in the loop and `await Promise.all(...)` once, after it. Bound the fan-out with a concurrency limit when the list is large.
+- **Batch the work** - collect inputs and use a bulk or set-based operation when the API supports it.
+- **Parallelize independent calls** - collect tasks in the loop and await them together after it, using a concurrency limit when the list is large.
 
-Keep the sequential `await` only when each iteration genuinely depends on the previous one, or when you are deliberately rate-limiting — and say so in a comment. Note: `for await (...)` async iteration and awaits inside a closure collected for a later `Promise.all` are not flagged.
+Keep the sequential `await` when each iteration depends on the previous one, or when you are deliberately rate-limiting. Add a short comment for intentional sequencing. Async iteration forms and awaits inside nested closures or methods are not flagged.

--- a/tests/guards-test.sh
+++ b/tests/guards-test.sh
@@ -19,7 +19,7 @@ mkpayload() {
 
 run_guard() {
   set +e
-  GUARD_OUT="$(printf '%s' "$1" | DEX_GUARD_EVENT=file python3 "$HANDLER" 2>/dev/null)"
+  GUARD_OUT="$(printf '%s' "$1" | env DEX_GUARD_EVENT=file python3 "$HANDLER" 2>/dev/null)"
   set -e
 }
 
@@ -52,6 +52,16 @@ assert_triggers "classic indexed for" \
   'for (let i = 0; i < items.length; i++) { await save(items[i]) }'
 assert_triggers "while loop with await" \
   'while (queue.length) { await process(queue.pop()) }'
+assert_triggers "Python for loop with await" \
+  'async def load(items):
+    for item in items:
+        await fetch(item)'
+assert_triggers "C# foreach loop with await" \
+  'foreach (var item in items) { await FetchAsync(item); }'
+assert_triggers "Rust-style loop with await expression" \
+  'for item in items { fetch(item).await; }'
+assert_triggers "brace loop without parenthesized header" \
+  'for item in items { await fetch(item) }'
 
 # --- should stay clean ---
 assert_clean "batched Promise.all" \
@@ -60,8 +70,19 @@ assert_clean "collect promises, await after loop" \
   'const ps = []; for (const i of items) { ps.push(repo.find(i.id)) } await Promise.all(ps)'
 assert_clean "deferred closure await in loop body" \
   'for (const i of items) { tasks.push(async () => { await repo.find(i) }) } await Promise.all(tasks.map((t) => t()))'
+assert_clean "expression-bodied async arrow in loop body" \
+  'for (const i of items) { tasks.push(async () => await repo.find(i)) } await Promise.all(tasks.map((t) => t()))'
+assert_clean "async object method in loop body" \
+  'for (const i of items) { tasks.push({ async run() { await repo.find(i) } }) } await Promise.all(tasks.map((t) => t.run()))'
+assert_clean "async class method in loop body" \
+  'for (const i of items) { tasks.push(class { async run() { await repo.find(i) } }) }'
 assert_clean "for await async iteration" \
   'for await (const chunk of stream) { handle(chunk) }'
+assert_clean "Python async for iteration" \
+  'async for item in stream:
+    await handle(item)'
+assert_clean "C# await foreach iteration" \
+  'await foreach (var item in stream) { await HandleAsync(item); }'
 assert_clean "loop pattern only inside a string" \
   'const sql = "for (x of y) { await z }"; doThing()'
 assert_clean "loop with no await" \

--- a/tests/guards-test.sh
+++ b/tests/guards-test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tests for the await-in-loop built-in guard (hooks/guards/await-in-loop.md +
+# the `await-in-loop` detector in hooks/guard-handler.py). Drives the guard
+# handler with synthetic file-event payloads and asserts whether the guard fires.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HANDLER="$ROOT/hooks/guard-handler.py"
+export DEX_DIR="$ROOT"
+
+pass=0
+fail=0
+
+# Build a file-event payload with the given file content.
+mkpayload() {
+  python3 -c 'import json,sys; print(json.dumps({"tool_input":{"file_path":"sample.ts","content":sys.argv[1]}}))' "$1"
+}
+
+run_guard() {
+  set +e
+  GUARD_OUT="$(printf '%s' "$1" | DEX_GUARD_EVENT=file python3 "$HANDLER" 2>/dev/null)"
+  set -e
+}
+
+assert_triggers() {
+  run_guard "$(mkpayload "$2")"
+  if printf '%s' "$GUARD_OUT" | grep -q 'warn-await-in-loop'; then
+    pass=$((pass + 1))
+  else
+    printf 'FAIL (expected trigger): %s\n' "$1" >&2
+    fail=$((fail + 1))
+  fi
+}
+
+assert_clean() {
+  run_guard "$(mkpayload "$2")"
+  if printf '%s' "$GUARD_OUT" | grep -q 'warn-await-in-loop'; then
+    printf 'FAIL (false positive): %s\n' "$1" >&2
+    fail=$((fail + 1))
+  else
+    pass=$((pass + 1))
+  fi
+}
+
+# --- should trigger ---
+assert_triggers "for-of with direct await" \
+  'for (const i of items) { await repo.find(i.id) }'
+assert_triggers "await nested in if inside loop" \
+  'for (const i of items) { if (i.ok) { await repo.find(i.id) } }'
+assert_triggers "classic indexed for" \
+  'for (let i = 0; i < items.length; i++) { await save(items[i]) }'
+assert_triggers "while loop with await" \
+  'while (queue.length) { await process(queue.pop()) }'
+
+# --- should stay clean ---
+assert_clean "batched Promise.all" \
+  'const r = await Promise.all(items.map((i) => repo.find(i.id)))'
+assert_clean "collect promises, await after loop" \
+  'const ps = []; for (const i of items) { ps.push(repo.find(i.id)) } await Promise.all(ps)'
+assert_clean "deferred closure await in loop body" \
+  'for (const i of items) { tasks.push(async () => { await repo.find(i) }) } await Promise.all(tasks.map((t) => t()))'
+assert_clean "for await async iteration" \
+  'for await (const chunk of stream) { handle(chunk) }'
+assert_clean "loop pattern only inside a string" \
+  'const sql = "for (x of y) { await z }"; doThing()'
+assert_clean "loop with no await" \
+  'for (const i of items) { total += i.value }'
+assert_clean "loop+await only inside a comment" \
+  '// for (const i of items) { await x(i) }
+doThing()'
+
+# --- realistic multi-line ---
+assert_triggers "multi-line service method" \
+  'async function load(items) {
+  const out = []
+  for (const i of items) {
+    const row = await repo.findById(i.id)
+    out.push(row)
+  }
+  return out
+}'
+
+printf 'guards-test: %d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
Add a brace-aware await-in-loop detector and warn-await-in-loop built-in file guard that flags await used directly inside a for/while loop body — the language-level signature of an N+1 query or sequential I/O.

The detector skips for-await async iteration and awaits inside closures collected for a later Promise.all, and ignores loop syntax in strings and comments. Includes tests/guards-test.sh (12 cases) and docs updates.

## Summary

## Testing

## Notes

Generated by Dex
